### PR TITLE
Update build-linux.yml to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
It seems that GitHub is phasing out the Ubuntu 20.04 image: https://github.com/jirimaier/DataPlotter/issues/9#issuecomment-2683235407

Given that 20.04 support is not strictly needed here, upgrade the Actions image to 22.04.