### PR TITLE
Add support for AppImages

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -36,7 +36,10 @@ jobs:
             ninja-build \
             pkg-config \
             qttools5-dev \
-            qttools5-dev-tools
+            qttools5-dev-tools \
+            gtk-update-icon-cache \
+            fuse libfuse2 \
+            zsync file appstream
 
       - name: Build DataPlotter
         run: |
@@ -47,10 +50,20 @@ jobs:
 
       - name: Package Debian Package
         run: |
-          python3 ./extras/deploy_debian_native/deploy.py
+          python3 ./extras/deploy_debian_native/deploy.py debian
 
       - name: Upload Debian Package
         uses: actions/upload-artifact@v4
         with:
           name: DataPlotter-Deb-Package
           path: ./extras/deploy_debian_native/deploy/*.deb
+
+      - name: Package AppImage
+        run: |
+          python3 ./extras/deploy_debian_native/deploy.py appimage
+
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: DataPlotter-AppImage
+          path: ./extras/deploy_debian_native/deploy/DataPlotter*.AppImage*

--- a/extras/deploy_debian_native/AppImageBuilder.yml
+++ b/extras/deploy_debian_native/AppImageBuilder.yml
@@ -1,0 +1,70 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
+version: 1
+AppDir:
+  app_info:
+    id: data-plotter
+    name: Data Plotter
+    icon: data-plotter
+    version: {version}
+    exec: usr/bin/data-plotter
+    exec_args: $@
+  apt:
+    arch:
+    - amd64
+    sources:
+    # jammy matches the GH Actions config
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy main universe
+      key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe
+      key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
+    - sourceline: deb http://security.ubuntu.com/ubuntu/ jammy-security main universe
+      key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
+    include:
+    # Qt libraries
+    - libqt5core5a
+    - libqt5gui5
+    - libqt5network5
+    - libqt5printsupport5
+    - libqt5qml5
+    - libqt5quickcontrols2-5
+    - libqt5quickwidgets5
+    - libqt5serialport5
+    - libqt5svg5
+    - libqt5widgets5
+    # required by Qt X11 backend
+    - libxcb-render0
+    - libxcb-shape0
+    - libxcb-shm0
+    - libxcb-xfixes0
+    # QML libraries
+    - qml-module-qtgraphicaleffects
+    - qml-module-qtcharts
+    - qml-module-qtqml
+    - qml-module-qtquick-controls
+    - qml-module-qtquick-controls2
+    - qml-module-qtquick-dialogs
+    - qml-module-qtquick-templates2
+    - qml-module-qtquick-window2
+    # misc other libs
+    - libbrotli1
+    - libbz2-1.0
+    exclude:
+    # follow https://github.com/AppImageCommunity/pkg2appimage/blob/master/excludelist
+    # and https://github.com/AppImageCommunity/pkg2appimage/blob/master/excludedeblist
+    - libfontconfig1
+    - libfreetype6
+    - libharfbuzz0b
+    - libice6
+    - libsm6
+    - libuuid1
+    - libgmp10
+    - zlib1g
+    - libcups2
+    - libtasn1-6
+  files:
+    exclude:
+    - usr/share/man
+    - usr/share/doc/*/README.*
+    - usr/share/doc/*/changelog.*
+    - usr/share/doc/*/NEWS.*
+    - usr/share/doc/*/TODO.*

--- a/extras/deploy_debian_native/deploy.py
+++ b/extras/deploy_debian_native/deploy.py
@@ -203,7 +203,7 @@ def main():
         raise Exception("Could not extract version from CMakeLists file")
     
     logging.info(f"Building DataPlotter version {version}")
-    deploy_root = "deploy"
+    deploy_root = os.path.abspath("deploy")
     deploy_dir = os.path.join(deploy_root, f"data-plotter_{version.replace('.','_')}_amd64")
     if os.path.exists(deploy_root):
         shutil.rmtree(deploy_root)


### PR DESCRIPTION
This PR proposes to distribute DataPlotter in an additional packaging format: [AppImage](https://en.wikipedia.org/wiki/AppImage). AppImages are mostly self-contained Linux executables - they have most of the libraries included within them.

## Why

I think that AppImages are a good compromise between the initial number of supported distributions and the effort required to achieve it.
 * One AppImage can work across multiple distributions. Based on (limited) testing via Docker, this DataPlotter AppImage works on Arch, Fedora, Debian and Ubuntu (albeit I have only tested them under X11).
 * The AppImage ships Qt libraries inside, which reduces the need for testing against multiple Qt versions (or working around their [bugs](https://bugreports.qt.io/browse/QTBUG-127575)).

To be fair, there are also some disadvantages:
* The AppImages do not integrate with the rest of the system - they are just executable files.
  * They do not have a desktop icon by default, although some workarounds exist (e.g. [appimaged](https://github.com/AppImageCommunity/appimaged)).
  * They do not update like the rest of the system typically does in Linux distros. Neither do the bundled libraries update.
  * The current DataPlotter AppImage is not able to do what https://github.com/jirimaier/DataPlotter/blob/main/deploy_linux/postinst does.

I think that a good overall Linux support strategy could be the following:
 * Provide an AppImage for all distributions as a "reference" / "known working" download for users.
 * Additionally provide classic repositories for Linux distributions via the OpenSUSE Build Service, just like QtRvSim does. 

### Why not Flatpak instead of AppImage?

I am biased by being a long-time user of Ubuntu. Ubuntu does not ship Flatpak by default, it instead uses Snap (although Flatpak can be installed additionally). Conversely, distributions like Fedora ship Flatpak by default and do not ship Snap (but it can also be installed additionally). I see this as a complication that AppImage does not have. 

However, when looked at from the system integration point of view, Flatpak/Snap are indeed superior solutions to AppImage (e.g. they have desktop icons, they have sandboxing and they have reusable core runtimes). Therefore, if the time resources allow it, I think that providing one or both of these would also be a good idea.

## How to use a built AppImage

You just have to download the `.AppImage` file from GitHub, mark it as executable via `chmod +x <file>.AppImage` and then run it.

There is also an additional `.AppImage.zsync` file built in GitHub Actions. I am not entirely sure how it works, but the way I understand it is the following:
 * There are tools such as https://appimage.github.io/AppImageUpdate/ that allow you to update AppImages automatically.
 * With the current AppImage build configuration, the utilities will look for a `.zsync` file within the latest GitHub release of this project.
 * The `.zsync` file probably allows the utility to download only the changed parts of the AppImage.

## How the packaging works

The process relies on two tools: [appimage-builder](https://github.com/AppImageCrafters/appimage-builder) and [appimagetool](https://github.com/AppImage/appimagetool).
 * `appimage-builder` basically downloads a predefined set of Ubuntu packages (i.e. Qt libraries and their dependencies) and extracts them next to a DataPlotter binary.
   * I decided against `linuxdeploy` and `linuxdeployqt` because they seem to offer less control. With `appimage-builder`, I can be sure that the AppImage will include all specified QML modules, even if DataPlotter does not use them out-of-the-box (they would be used only by user-provided scripts).
 * `appimagetool` packages the directory with DataPlotter and libraries into a self-contained executable.
   * `appimage-builder` can do this too, but it uses an older `appimagetool` that has some disadvantages.

## Miscellaneous

Supersedes: https://github.com/jirimaier/DataPlotter/pull/11
AppImage built in my fork: [Actions log](https://github.com/JakubVanek/DataPlotter/actions/runs/13573306489/job/37943460538), [Artifact zip](https://github.com/JakubVanek/DataPlotter/actions/runs/13573306489/artifacts/2665534142)
Cc: @ppisa (I just want to provide an update that something is happening with this).