### PR TITLE
Linux packaging fix: use "data-plotter" final executable name instead of "DataPlotter"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(PACKAGE_OUTPUT_PATH "${EXECUTABLE_OUTPUT_PATH}/pkg"
 # C defines, respectively.
 set(MAIN_PROJECT_NAME "${PROJECT_NAME}")
 set(MAIN_PROJECT_VERSION "${PROJECT_VERSION}")
-set(MAIN_PROJECT_APPID "cz.cvut.edu.comparch.qtrvsim")
+set(MAIN_PROJECT_APPID "cz.cvut.fel.embedded.sdi.data-plotter")
 set(MAIN_PROJECT_ORGANIZATION "FEE CTU")
 set(MAIN_PROJECT_HOMEPAGE_URL "${PROJECT_HOMEPAGE_URL}")
 #string(TOLOWER "${PROJECT_NAME}" MAIN_PROJECT_NAME_LOWER)
@@ -233,6 +233,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
 else()
     add_executable(DataPlotter ${PROJECT_SOURCES} ${APP_RES} ${QT_RES})
 endif()
+set_target_properties(DataPlotter PROPERTIES OUTPUT_NAME ${MAIN_EXECUTEBLE_NAME})
 
 # Define the preprocessor macro for QCustomPlot OpenGL support
 target_compile_definitions(DataPlotter PRIVATE QCUSTOMPLOT_USE_OPENGL)
@@ -284,6 +285,7 @@ add_dependencies(DataPlotter lupdate)
 # in corresponding CMakeLists.txt.
 
 if (NOT "${WASM}")
+    install(TARGETS DataPlotter)
 #   install(FILES "extras/deploy_debian_native/icons/icon.svg"
 #           DESTINATION "share/icons/hicolor/scalable/apps"
 #           RENAME "${MAIN_PROJECT_NAME_LOWER}.svg")

--- a/extras/deploy_debian_native/deploy.py
+++ b/extras/deploy_debian_native/deploy.py
@@ -47,7 +47,7 @@ def copy_files(deploy_dir):
     files = {
         "control": os.path.join(deploy_dir, "DEBIAN", "control"),
         "qt.conf": os.path.join(deploy_dir, "usr", "bin", "qt.conf"),
-        "../../build/target/DataPlotter": os.path.join(deploy_dir, "usr", "bin", "data-plotter"),
+        "../../build/target/data-plotter": os.path.join(deploy_dir, "usr", "bin", "data-plotter"),
         "../../documentation/license.txt": os.path.join(deploy_dir, "usr", "share", "doc", "data-plotter", "copyright"),
         "icon.png": os.path.join(deploy_dir, "usr", "share", "icons", "hicolor", "256x256", "apps", "data-plotter.png"),
         "data-plotter.desktop": os.path.join(deploy_dir, "usr", "share", "applications", "data-plotter.desktop")

--- a/extras/packaging/rpm/spec.in
+++ b/extras/packaging/rpm/spec.in
@@ -31,21 +31,21 @@ Group:          Office/Visualization/Other
 URL:            @PACKAGE_URL@
 Source:         @PACKAGE_SOURCE_ARCHIVE_FILE@
 BuildRequires:  cmake
+BuildRequires:  cmake(Qt5LinguistTools)
 BuildRequires:  gcc-c++
+BuildRequires:  hicolor-icon-theme
 BuildRequires:  pkgconfig
-BuildRequires:  pkgconfig(Qt5Widgets)
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
-BuildRequires:  pkgconfig(Qt5SerialPort)
-BuildRequires:  pkgconfig(Qt5PrintSupport)
+BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5OpenGL)
+BuildRequires:  pkgconfig(Qt5PrintSupport)
 BuildRequires:  pkgconfig(Qt5Qml)
-BuildRequires:  pkgconfig(Qt5QuickWidgets)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(Qt5QuickControls2)
-BuildRequires:  pkgconfig(Qt5Network)
-BuildRequires:  cmake(Qt5LinguistTools)
-BuildRequires:  hicolor-icon-theme
+BuildRequires:  pkgconfig(Qt5QuickWidgets)
+BuildRequires:  pkgconfig(Qt5SerialPort)
+BuildRequires:  pkgconfig(Qt5Widgets)
 
 %if ! 0%{?suse_version}
 BuildRequires:  desktop-file-utils
@@ -54,8 +54,8 @@ BuildRequires:  qt5-qttools
 %endif
 
 %if 0%{?suse_version}
-BuildRequires:  update-desktop-files
 BuildRequires:  libqt5-linguist
+BuildRequires:  update-desktop-files
 %endif
 
 %description
@@ -81,17 +81,16 @@ BuildRequires:  libqt5-linguist
 %endif
 
 %if 0%{?fedora} || 0%{?rhel} || 0%{?centos}
-#desktop-file-validate %{buildroot}/usr/share/applications/@PACKAGE_NAME@.desktop
-desktop-file-validate %{buildroot}/usr/share/applications/data-plotter.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/@PACKAGE_NAME@.desktop
 %endif
 
 # TODO: this should be generated from CMake
 %files
-/usr/bin/@PACKAGE_NAME@
-#/usr/share/icons/hicolor/scalable/apps/@PACKAGE_NAME@.svg
-/usr/share/icons/hicolor/256x256/apps/@PACKAGE_NAME@.png
-/usr/share/applications/@PACKAGE_NAME@.desktop
-#/usr/share/metainfo/cz.cvut.fel.embedded.@PACKAGE_NAME@.metainfo.xml
+%{_bindir}/@MAIN_EXECUTEBLE_NAME@
+#%{_datadir}/icons/hicolor/scalable/apps/@PACKAGE_NAME@.svg
+%{_datadir}/icons/hicolor/256x256/apps/@PACKAGE_NAME@.png
+%{_datadir}/applications/@PACKAGE_NAME@.desktop
+#%{_datadir}/metainfo/cz.cvut.fel.embedded.@PACKAGE_NAME@.metainfo.xml
 
 %license documentation/license.txt
 %doc README.md


### PR DESCRIPTION
The executable name chosen for the GNU/Linux build was "data-plotter" even before my first attempt for proper Linux packaging so I have tried to keep it. The option to use "DataPlotter" name even on Linux (same as on Windows) is possible, but CammelCase it is much less common in the /usr/bin. In the fact I have no such binary on my system.

Automatic lover case to "dataplotter" is possible but I think that it is much less distinguishable.

Corrected missing executable install as well
  install(TARGETS DataPlotter)
to install final executable.

The SPEC file for Fedora and SUSE cleaned according to Lubos Kocman review of QtRvSim SPEC at  InstallFest 2025.