### PR TITLE
Linux packaging: update version to 3.3.2 and related script update

### DIFF
--- a/extras/packaging/add-to-changelog.sh
+++ b/extras/packaging/add-to-changelog.sh
@@ -1,15 +1,35 @@
 #!/usr/bin/env bash
 
 CHANGELOG_FILE="extras/packaging/deb/debian/changelog"
+MAIN_PROJECT_NAME_LOWER="data-plotter"
 
-if [ $# -lt 1 ]; then
-  echo "Version has to be specified"
+if false ; then
+  CMAKELISTS_DIR="$( old_pwd="" ;  while [ ! -e CMakeLists.txt ] ; do if [ "$old_pwd" = `pwd`  ] ; then exit 1 ; else old_pwd="$(pwd)" ; cd -L .. 2>/dev/null ; fi ; done ; pwd )"
+  if [ $? -ne 0 ] ; then
+    echo 'Can not found top level project directory with "CMakeLists.txt" file'
+    exit 1
+  fi
+  cd "$CMAKELISTS_DIR"
+else
+  cd "$(dirname "$0")/../.."
+  CMAKELISTS_DIR="$(pwd)"
+fi
+
+if [ $# -ge 1 ]; then
+  V_TXT="$1"
+else
+  V_TXT="$(sed -n '/^[ \t]*project *(/{s///; :1; /) *$/!{N; b1;}; s///; s/^.*VERSION[\t ]\+\([^ ]*\)\b.*$/\1/p};' "$CMAKELISTS_DIR/CMakeLists.txt")"
+fi
+
+if [ -z "$V_TXT" ] ; then
+  echo 'Version is not specified as argument neither determined from "CMakeLists.txt" file'
   exit 1
 fi
 
-V_TXT="$1"
-
-cd "$(dirname "$0")/../.."
+V_TXT_W_SUF="$( echo "$V_TXT" | sed -n 's/\(.*-.*\)/\1/p')"
+if [ -z "$V_TXT_W_SUF" ] ; then
+  V_TXT_W_SUF="$V_TXT-1"
+fi
 
 V_DATE_MDY="$(date '+%m/%d/%Y')"
 V_DATE_YMD="$(date '+%Y-%m-%d')"
@@ -18,13 +38,13 @@ V_DATE_RFC="$(date -R)"
 V_USER_NAME="$(git config user.name)"
 V_USER_EMAIL="$(git config user.email)"
 
-if grep -q "qtrvsim ($V_TXT)" $CHANGELOG_FILE; then
+if grep -q "$MAIN_PROJECT_NAME_LOWER ($V_TXT_W_SUF)" $CHANGELOG_FILE; then
   sed --in-place \
     -e '1,/^ -- .*$/s/^ -- .*$/'" -- $V_USER_NAME <$V_USER_EMAIL>  $V_DATE_RFC/" \
     $CHANGELOG_FILE
 else
   cat >$CHANGELOG_FILE.tmp <<EOF
-qtrvsim ($V_TXT) unstable; urgency=medium
+$MAIN_PROJECT_NAME_LOWER ($V_TXT_W_SUF) unstable; urgency=medium
 
   * Debian package updated to version $V_TXT.
 
@@ -35,6 +55,9 @@ EOF
   mv $CHANGELOG_FILE.tmp $CHANGELOG_FILE
 fi
 
+if [ -z "$EDITOR" ] ; then
+  EDITOR=nano
+fi
 $EDITOR $CHANGELOG_FILE
 
 echo Press enter to continue
@@ -52,7 +75,7 @@ git tag -s v$V_TXT
 
 # TODO
 #if [ -x /usr/lib/obs-build/changelog2spec ]; then
-#  /usr/lib/obs-build/changelog2spec debian/changelog >../qtrvsim.changes
+#  /usr/lib/obs-build/changelog2spec debian/changelog >../$MAIN_PROJECT_NAME_LOWER.changes
 #elif [ -x /usr/lib/build/changelog2spec ]; then
-#  /usr/lib/build/changelog2spec debian/changelog >../qtrvsim.changes
+#  /usr/lib/build/changelog2spec debian/changelog >../$MAIN_PROJECT_NAME_LOWER.changes
 #fi

--- a/extras/packaging/deb/debian/changelog
+++ b/extras/packaging/deb/debian/changelog
@@ -1,3 +1,9 @@
+data-plotter (3.3.2-1) unstable; urgency=medium
+
+  * Debian package updated to version 3.3.2.
+
+ -- Pavel Pisa <pisa@fel.cvut.cz>  Mon, 24 Mar 2025 23:26:19 +0100
+
 data-plotter (3.3.1-1) unstable; urgency=medium
 
   * Initial Debian packaging attempt


### PR DESCRIPTION
There are some rough edges for GNU/Linux packaging still. The file

  extras/packaging/deb/debian/changelog

has to be kept in sync with the project version specified in CMakeLists.txt to keep `make open_build_service_bundle` and following Debian build to match on version and work. There is some helper script (`extras/packaging/add-to-changelog.sh`) to add Debian changelog entry. But it is quite hackish and possible to be run only with full featured POSIX shell and tools (it would require MinGW at least on Windows). It could be rewritten to Python in future... but when I find time is a question... Entries could be added manually as well...

I am not sure if changelog should be somehow updated/fixed during `make open_build_service_bundle` automatically... The change and content should be more under some human control...

The Debian package build sequence looks next way now. But with Ubuntu it can be done on their Lauchpad without need to interact with the tools. For OpenSuse build service bundle export is needed and then commit to OSC. That could be automated to grab repository too

```
rm -rf DataPlotter-build
mkdir -p DataPlotter-build
(cd DataPlotter-build && cmake -DDEV_MODE=true ../DataPlotter ) || exit 1
(cd DataPlotter-build && make open_build_service_bundle ) || exit 1
(cd DataPlotter-build/target/pkg && cp -v * /home/pi/repo/emu/qtmips/home:ppisa/dataplotter ) || exit 1
rm -rf DataPlotter-deb
mkdir -p DataPlotter-deb
cp DataPlotter-build/target/pkg/* DataPlotter-deb
cd DataPlotter-deb
dpkg-source -x data-plotter_*.dsc
cd data-plotter-[0-9].[0-9].[0-9]
dpkg-buildpackage
```