### PR TITLE
Fix missing text in translation files

### DIFF
--- a/translations/dataplotter_cs.ts
+++ b/translations/dataplotter_cs.ts
@@ -69,7 +69,7 @@
     <message>
         <location filename="../src/mainwindow/appsettings.cpp" line="370"/>
         <source>Windows</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows</translation>
     </message>
 </context>
 <context>
@@ -228,7 +228,7 @@
     <message>
         <location filename="../src/forms/developeroptions.ui" line="347"/>
         <source>E Next line</source>
-        <translation></translation>
+        <translation>E Další řádek</translation>
     </message>
     <message>
         <location filename="../src/forms/developeroptions.ui" line="352"/>
@@ -1028,7 +1028,7 @@
         <location filename="../src/forms/mainwindow.ui" line="5927"/>
         <location filename="../src/forms/mainwindow.ui" line="6037"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../src/forms/mainwindow.ui" line="6184"/>

--- a/translations/dataplotter_en.ts
+++ b/translations/dataplotter_en.ts
@@ -69,7 +69,7 @@
     <message>
         <location filename="../src/mainwindow/appsettings.cpp" line="370"/>
         <source>Windows</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows</translation>
     </message>
 </context>
 <context>
@@ -1028,7 +1028,7 @@
         <location filename="../src/forms/mainwindow.ui" line="5927"/>
         <location filename="../src/forms/mainwindow.ui" line="6037"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../src/forms/mainwindow.ui" line="6184"/>
@@ -1099,7 +1099,7 @@
     <message>
         <location filename="../src/forms/mainwindow.ui" line="8081"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable OpenGL hardware acceleration for drawing main plot (recommended for logic channels with fill under graph line)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable OpenGL hardware acceleration for drawing main plot (recommended for logic channels with fill under graph line)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../src/forms/mainwindow.ui" line="3731"/>


### PR DESCRIPTION
## Summary
- add missing translations for `Windows` entry
- provide Czech text for 'Next line'
- fill in placeholder HTML entries in both languages

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68401ef596fc832f8dabbc7c3be9ed9d